### PR TITLE
Do not report a group when GenericReport is initialized with group: nil

### DIFF
--- a/lib/innsights/action.rb
+++ b/lib/innsights/action.rb
@@ -39,7 +39,7 @@ module Innsights
       if @record.present? && (@report.report_group.is_a?(Symbol) || @report.report_group.is_a?(Proc))
         Actions::Group.new(@record, method: @report.report_group)
 
-      elsif @report && @report.report_group.present?
+      elsif @report && @report.instance_variables.include?(:@report_group)
         Actions::Group.new(@report.report_group)
 
       else

--- a/lib/innsights/config/reports/generic_report.rb
+++ b/lib/innsights/config/reports/generic_report.rb
@@ -15,7 +15,7 @@ module Innsights
     def set_options(options)
       if options.is_a?(Hash)
         option_equivalences.each do |self_k, api_k|
-          self.instance_variable_set("@#{self_k}", options[api_k]) if options[api_k]
+          self.instance_variable_set("@#{self_k}", options[api_k]) if options.has_key?(api_k)
         end
       else
         @report_user = options

--- a/spec/innsights/action_spec.rb
+++ b/spec/innsights/action_spec.rb
@@ -22,10 +22,15 @@ describe Innsights::Action do
         Innsights::Action.new(report, post)
 
       end
-      it 'Sets the group form user when there is no explicit group' do
+      it 'Sets the group from user when there is no explicit group' do
         Innsights::Actions::Group.should_not_receive(:new).with(group)
         Innsights::Actions::Group.should_receive(:new)
                                  .with(instance_of(Innsights::Actions::User))
+        Innsights::Action.new(report, post)
+      end
+      it 'Sets an invalid group when report explictily sets report_group to nil' do
+        report.report_group = nil
+        Innsights::Actions::Group.should_receive(:new).with(nil)
         Innsights::Action.new(report, post)
       end
     end


### PR DESCRIPTION
Estábamos tratando de enviar un reporte genérico para un usuario pero _que no agregara_ la acción al grupo, y lo intentábamos de la siguiente manera:

``` ruby
Innsights.report('Trayecto confirmado', user: @user, group: nil).run
```

El problema era que en el setup tenemos:

``` ruby
Innsights.setup do
  user :User do
    group :company
  end
end
```

por lo que estaba sacando el grupo del usuario.

Con este patch, cuando se inicializa un generic report con:

``` ruby
Innsights.report('Trayecto confirmado', user: @user, group: nil).run
```

No se incluye un grupo en el action.

Y cuando se inicializa así

``` ruby
Innsights.report('Trayecto confirmado', user: @user).run
```

Se saca el grupo del usuario y se incluye en el action (como sucedía ántes).
