### PR TITLE
Replaced safe constantize with constantize in controller report

### DIFF
--- a/lib/innsights/config/reports/controller_report.rb
+++ b/lib/innsights/config/reports/controller_report.rb
@@ -47,7 +47,7 @@ module Innsights
 
     # TODO: This is not the right way to require a controller
     def controller_class
-      "#{@controller.classify.pluralize}Controller".safe_constantize
+      "#{@controller.classify.pluralize}Controller".constantize
     end
 
     private


### PR DESCRIPTION
Safe constantize was introduced since Rails 3.2. Constantize should be enough.
