### PR TITLE
Added to Innsights::Report the ability to overwrite the user group configuration, with nil

### DIFF
--- a/lib/innsights/report.rb
+++ b/lib/innsights/report.rb
@@ -29,7 +29,7 @@ module Innsights
       options ||= {}
       @name = name
       @user_object = options[:user]
-      @group_object = fetch_group(options[:group])
+      @group_object = fetch_group(options)
       @created_at = options[:created_at] || Time.now
       @metrics = options[:measure] || {}
     end
@@ -85,8 +85,8 @@ module Innsights
 
     private
 
-    def fetch_group(group_object)
-      return group_object if group_object.present?
+    def fetch_group(options)
+      return options[:group] if options.has_key? :group
       return user.group if user.present?
       nil
     end

--- a/spec/dummy_spec/integration/report_spec.rb
+++ b/spec/dummy_spec/integration/report_spec.rb
@@ -44,7 +44,7 @@ describe Innsights::Report do
   describe "#report" do
     it 'Can report a manual action' do
       Innsights.client.should_receive(:report)
-      Innsights.report('Mention', dude).run
+      Innsights.report('Mention', user: dude).run
     end
     it 'Can create a custom create action' do
       Dude.after_create lambda {|record| Innsights.report('Mention').run }

--- a/spec/innsights/report_spec.rb
+++ b/spec/innsights/report_spec.rb
@@ -37,6 +37,28 @@ describe Innsights::Report do
       r = Innsights::Report.new("Mention", group: company)
       r.group.object.should == company
     end
+    it 'Takes the user group as default' do
+      company = Company.new
+      user.company = company
+      Innsights.group_call = :company
+      r = Innsights::Report.new("Mention", user: user)
+      r.group.object.should == company
+    end
+    it 'Can override the group if given' do
+      company = Company.new name: "Original"
+      user.company = company
+      company_override = Company.new name: "Override"
+      Innsights.group_call = :company
+      r = Innsights::Report.new("Mention", user: user, group: company_override)
+      r.group.object.should == company_override
+    end
+    it 'Can override the group with nil' do
+      company = Company.new name: "Original"
+      user.company = company
+      Innsights.group_call = :company
+      r = Innsights::Report.new("Mention", user: user, group: nil)
+      r.group.should == nil
+    end
     it 'Can add a created_at' do
       time = Time.now
       r = Innsights::Report.new("Mention", created_at: time)


### PR DESCRIPTION
### Innsights config

``` ruby
Innsights.setup do
  user :User do
    group :company
  end
end
```
### Before

``` ruby
report = Innsights::Report.new("Mention", user: user)
report.group.object.should eq user.company

report = Innsights::Report.new("Mention", user: user, group: nil)
report.group.object.should eq user.company
```
### After

``` ruby
report = Innsights::Report.new("Mention", user: user)
report.group.object.should eq user.company

report = Innsights::Report.new("Mention", user: user, group: nil)
report.group.should eq nil
```
